### PR TITLE
Fixed null and slash path issues and formatting

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -23,6 +23,31 @@ describe('Integration', () => {
     server.listen(3000);
   });
   describe('Router', () => {
+    it('maps to the null or slash path', async (done) => {
+      const router: Router = new Router();
+      router.addHandler('/', CatEndpoint);
+      server.setRouter(router);
+
+      let result = await got('http://localhost:3000/');
+      expect(result.statusCode).toEqual(200);
+      expect(result.body).toEqual('Cat');
+      result = await got('http://localhost:3000');
+      expect(result.statusCode).toEqual(200);
+      expect(result.body).toEqual('Cat');
+
+      const routerWithNull: Router = new Router();
+      routerWithNull.addHandler('', CatEndpoint);
+      server.setRouter(routerWithNull);
+
+      result = await got('http://localhost:3000/');
+      expect(result.statusCode).toEqual(200);
+      expect(result.body).toEqual('Cat');
+      result = await got('http://localhost:3000');
+      expect(result.statusCode).toEqual(200);
+      expect(result.body).toEqual('Cat');
+
+      done();
+    });
     it('maps within one router at single level', async (done) => {
       const router: Router = new Router();
       router.addHandler('/dog', DogEndpoint);

--- a/src/network/Response.ts
+++ b/src/network/Response.ts
@@ -1,7 +1,6 @@
 import { ServerResponse } from 'http';
 
 export default class Response extends ServerResponse {
-
   send(text: string) {
     this.writeHead(200, { 'Content-Type': 'text/plain' });
     this.write(text);

--- a/src/path/Path.ts
+++ b/src/path/Path.ts
@@ -15,7 +15,7 @@ export default class Path {
   }
 
   getCorrectPathString(path: string): string {
-    if (path === '') {
+    if (path === '' || path === '/') {
       return '/';
     }
     let correctedPath: string;


### PR DESCRIPTION
This adds the tests that were missing for linking the null path to an endpoint